### PR TITLE
Fix Linux Kafka Issues

### DIFF
--- a/build/linux/ncpa.spec
+++ b/build/linux/ncpa.spec
@@ -192,7 +192,7 @@ fi
 %defattr(0644,root,root,0755)
 /usr/local/ncpa/*.githash
 /usr/local/ncpa/frozen_application_license.txt
-/usr/local/ncpa/lib/*.py
+#/usr/local/ncpa/lib/*.py
 /usr/local/ncpa/lib/*.zip
 /usr/local/ncpa/build_resources
 /usr/local/ncpa/listener

--- a/build/resources/require.txt
+++ b/build/resources/require.txt
@@ -12,4 +12,4 @@ gevent-websocket
 cffi
 appdirs
 packaging
-kafka
+kafka-python

--- a/build/resources/require.win.txt
+++ b/build/resources/require.win.txt
@@ -11,6 +11,6 @@ gevent
 gevent-websocket
 cffi
 appdirs
-kafka
+kafka-python
 packaging
 pywin32


### PR DESCRIPTION
Fixed Kafka not working on Linux and updated imported/installed kafka package to the proper modern python 3 kafka package